### PR TITLE
Make unified container truly single-container with embedded Redis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && apt-get install -y \
-    python3.10 python3-pip supervisor \
+    python3.10 python3-pip supervisor redis-server \
     libopus0 libx264-163 libx265-199 libvpx7 libnuma1 \
     libva2 libva-drm2 libmfx1 \
     && rm -rf /var/lib/apt/lists/*
@@ -79,7 +79,7 @@ COPY worker/app /app/worker
 COPY --from=frontend-build /frontend/build /app/frontend-build
 
 # Create necessary directories
-RUN mkdir -p /app/uploads /app/outputs /var/log/supervisor
+RUN mkdir -p /app/uploads /app/outputs /var/log/supervisor /var/lib/redis /var/log/redis
 
 # Configure supervisord
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/docker-compose.hub-unified.yml
+++ b/docker-compose.hub-unified.yml
@@ -1,31 +1,16 @@
-# Docker Compose for pulling unified 8mb.local from Docker Hub
-# Simplified single-container deployment
-
 services:
-  redis:
-    image: redis:7-alpine
-    container_name: 8mblocal-redis
-    command: redis-server --appendonly yes
-    volumes:
-      - redis-data:/data
-    networks:
-      - 8mblocal-net
-    restart: unless-stopped
-
   app:
     image: jms1717/8mblocal:latest
     container_name: 8mblocal-app
-    depends_on:
-      - redis
     ports:
       - "8000:8000"
     volumes:
       - ./uploads:/app/uploads
       - ./outputs:/app/outputs
     environment:
-      - REDIS_URL=redis://redis:6379/0
-      - CELERY_BROKER_URL=redis://redis:6379/0
-      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+      - REDIS_URL=redis://127.0.0.1:6379/0
+      - CELERY_BROKER_URL=redis://127.0.0.1:6379/0
+      - CELERY_RESULT_BACKEND=redis://127.0.0.1:6379/0
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=all
     networks:
@@ -38,9 +23,6 @@ services:
               count: all
               capabilities: [gpu]
     restart: unless-stopped
-
-volumes:
-  redis-data:
 
 networks:
   8mblocal-net:

--- a/docker-compose.unified.yml
+++ b/docker-compose.unified.yml
@@ -1,30 +1,18 @@
 services:
-  redis:
-    image: redis:7-alpine
-    container_name: 8mblocal-redis
-    command: redis-server --appendonly yes
-    volumes:
-      - redis-data:/data
-    networks:
-      - 8mblocal-net
-    restart: unless-stopped
-
   app:
     build:
       context: .
       dockerfile: Dockerfile
     container_name: 8mblocal-app
-    depends_on:
-      - redis
     ports:
       - "8000:8000"
     volumes:
       - ./uploads:/app/uploads
       - ./outputs:/app/outputs
     environment:
-      - REDIS_URL=redis://redis:6379/0
-      - CELERY_BROKER_URL=redis://redis:6379/0
-      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+      - REDIS_URL=redis://127.0.0.1:6379/0
+      - CELERY_BROKER_URL=redis://127.0.0.1:6379/0
+      - CELERY_RESULT_BACKEND=redis://127.0.0.1:6379/0
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=all
     networks:
@@ -37,9 +25,6 @@ services:
               count: all
               capabilities: [gpu]
     restart: unless-stopped
-
-volumes:
-  redis-data:
 
 networks:
   8mblocal-net:

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -4,6 +4,16 @@ user=root
 logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 
+[program:redis]
+command=redis-server --bind 127.0.0.1 --port 6379 --dir /var/lib/redis --appendonly yes
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+priority=1
+
 [program:backend]
 command=uvicorn backend.main:app --host 0.0.0.0 --port 8000
 directory=/app
@@ -14,6 +24,7 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 environment=PYTHONPATH="/app"
+priority=10
 
 [program:worker]
 command=celery -A worker.celery_app worker --loglevel=info -n 8mblocal@%%h --concurrency=1
@@ -25,3 +36,4 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 environment=PYTHONPATH="/app",NVIDIA_VISIBLE_DEVICES="all"
+priority=20


### PR DESCRIPTION
- Add redis-server to unified Dockerfile
- Update supervisord.conf to manage Redis alongside backend/worker
- Change REDIS_URL to 127.0.0.1 (localhost) in compose files
- Remove separate Redis container from unified deployment
- Now truly ONE container: 8mblocal-app (Redis + Backend + Worker + Frontend)
- Simplifies deployment to absolute minimum