### PR TITLE
feat: Add Apple Silicon support with VideoToolbox hardware encoding (#15)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Thumbs.db
 # Python
 __pycache__/
 *.pyc
+venv/
 
 # Node
 node_modules/

--- a/README.md
+++ b/README.md
@@ -543,10 +543,36 @@ If progress still doesn't update until completion, check your proxy logs and ver
 5. Use the appropriate docker command for your GPU
 
 #### macOS
+
+**Option 1: CPU-only (Docker)**
 1. Install Docker Desktop
-2. Note: No GPU acceleration available on macOS (Docker runs in Linux VM without GPU passthrough)
-3. Use CPU-only docker command
-4. Performance will be slower but functional
+2. Use the standard docker command
+3. Note: Docker on macOS runs in a Linux VM without GPU passthrough, so encoding uses CPU
+
+**Option 2: Hardware acceleration with Apple Silicon (Hybrid Setup)**
+
+For hardware-accelerated encoding on M1/M2/M3/M4 Macs, use a hybrid setup with Docker for services and a native worker:
+
+1. Install Docker Desktop
+2. Start containers with macOS-specific compose:
+   ```bash
+   docker-compose -f docker-compose.macos.yml up -d
+   ```
+3. Run the setup script:
+   ```bash
+   ./scripts/macos-setup.sh
+   ```
+4. Start the native worker (in a new terminal):
+   ```bash
+   source venv/bin/activate
+   export REDIS_URL=redis://localhost:6380/0
+   export UPLOAD_DIR=./uploads
+   export OUTPUT_DIR=./outputs
+   export PYTHONPATH=.:./backend-api:./worker
+   celery -A worker.celery_app worker --loglevel=info
+   ```
+
+This enables VideoToolbox hardware encoding (H.264, HEVC) using Apple Silicon GPU. See [docs/GPU_SUPPORT.md](docs/GPU_SUPPORT.md) for details.
 
 ### Verify Installation
 

--- a/backend-api/app/models.py
+++ b/backend-api/app/models.py
@@ -17,7 +17,7 @@ class CompressRequest(BaseModel):
     job_id: str
     filename: str
     target_size_mb: float
-    video_codec: Literal['av1_nvenc','hevc_nvenc','h264_nvenc','libx264','libx265','libsvtav1','libaom-av1','h264_qsv','hevc_qsv','av1_qsv','h264_vaapi','hevc_vaapi','av1_vaapi'] = 'av1_nvenc'
+    video_codec: Literal['av1_nvenc','hevc_nvenc','h264_nvenc','libx264','libx265','libsvtav1','libaom-av1','h264_qsv','hevc_qsv','av1_qsv','h264_vaapi','hevc_vaapi','av1_vaapi','h264_videotoolbox','hevc_videotoolbox'] = 'av1_nvenc'
     audio_codec: Literal['libopus','aac','none'] = 'libopus'  # Added 'none' for mute
     audio_bitrate_kbps: int = 128
     preset: Literal['p1','p2','p3','p4','p5','p6','p7','extraquality'] = 'p6'  # Added 'extraquality'
@@ -65,7 +65,7 @@ class PasswordChange(BaseModel):
 
 class DefaultPresets(BaseModel):
     target_mb: float = 25
-    video_codec: Literal['av1_nvenc','hevc_nvenc','h264_nvenc','libx264','libx265','libsvtav1','libaom-av1','h264_qsv','hevc_qsv','av1_qsv','h264_vaapi','hevc_vaapi','av1_vaapi'] = 'av1_nvenc'
+    video_codec: Literal['av1_nvenc','hevc_nvenc','h264_nvenc','libx264','libx265','libsvtav1','libaom-av1','h264_qsv','hevc_qsv','av1_qsv','h264_vaapi','hevc_vaapi','av1_vaapi','h264_videotoolbox','hevc_videotoolbox'] = 'av1_nvenc'
     audio_codec: Literal['libopus','aac','none'] = 'libopus'  # Added 'none' for mute
     preset: Literal['p1','p2','p3','p4','p5','p6','p7','extraquality'] = 'p6'  # Added 'extraquality'
     audio_kbps: Literal[64,96,128,160,192,256] = 128
@@ -93,6 +93,9 @@ class CodecVisibilitySettings(BaseModel):
     h264_vaapi: bool = True
     hevc_vaapi: bool = True
     av1_vaapi: bool = True
+    # VideoToolbox (macOS/Apple Silicon)
+    h264_videotoolbox: bool = True
+    hevc_videotoolbox: bool = True
     # CPU
     libx264: bool = True
     libx265: bool = True
@@ -102,7 +105,7 @@ class CodecVisibilitySettings(BaseModel):
 class PresetProfile(BaseModel):
     name: str
     target_mb: float
-    video_codec: Literal['av1_nvenc','hevc_nvenc','h264_nvenc','libx264','libx265','libsvtav1','libaom-av1','h264_qsv','hevc_qsv','av1_qsv','h264_vaapi','hevc_vaapi','av1_vaapi']
+    video_codec: Literal['av1_nvenc','hevc_nvenc','h264_nvenc','libx264','libx265','libsvtav1','libaom-av1','h264_qsv','hevc_qsv','av1_qsv','h264_vaapi','hevc_vaapi','av1_vaapi','h264_videotoolbox','hevc_videotoolbox']
     audio_codec: Literal['libopus','aac','none']
     preset: Literal['p1','p2','p3','p4','p5','p6','p7','extraquality']
     audio_kbps: Literal[64,96,128,160,192,256]

--- a/backend-api/app/settings_manager.py
+++ b/backend-api/app/settings_manager.py
@@ -398,6 +398,9 @@ def get_codec_visibility_settings() -> dict:
         'h264_amf': get_bool('CODEC_H264_AMF'),
         'hevc_amf': get_bool('CODEC_HEVC_AMF'),
         'av1_amf': get_bool('CODEC_AV1_AMF'),
+        # VideoToolbox (macOS/Apple Silicon)
+        'h264_videotoolbox': get_bool('CODEC_H264_VIDEOTOOLBOX'),
+        'hevc_videotoolbox': get_bool('CODEC_HEVC_VIDEOTOOLBOX'),
         # CPU
         'libx264': get_bool('CODEC_LIBX264'),
         'libx265': get_bool('CODEC_LIBX265'),
@@ -422,6 +425,8 @@ def update_codec_visibility_settings(settings: dict):
         'h264_amf': 'CODEC_H264_AMF',
         'hevc_amf': 'CODEC_HEVC_AMF',
         'av1_amf': 'CODEC_AV1_AMF',
+        'h264_videotoolbox': 'CODEC_H264_VIDEOTOOLBOX',
+        'hevc_videotoolbox': 'CODEC_HEVC_VIDEOTOOLBOX',
         'libx264': 'CODEC_LIBX264',
         'libx265': 'CODEC_LIBX265',
         'libaom_av1': 'CODEC_LIBAOM_AV1',

--- a/docker-compose.macos.yml
+++ b/docker-compose.macos.yml
@@ -1,0 +1,26 @@
+# Docker Compose for macOS with Apple Silicon
+#
+# This configuration runs Redis, frontend, and backend API in Docker while
+# exposing Redis on port 6380 for a native macOS worker to connect.
+#
+# Usage:
+#   1. Start containers: docker-compose -f docker-compose.macos.yml up -d
+#   2. Run native worker: see scripts/macos-setup.sh
+#
+# Note: No GPU passthrough since Docker Desktop on macOS runs in a Linux VM.
+# Hardware acceleration is provided by the native macOS worker using VideoToolbox.
+
+services:
+  8mblocal:
+    image: jms1717/8mblocal:latest
+    container_name: 8mblocal
+    ports:
+      - "8001:8001"
+      - "6380:6379"  # Expose Redis on 6380 to avoid conflict with native Redis
+    volumes:
+      - ./uploads:/app/uploads
+      - ./outputs:/app/outputs
+      - ./.env:/app/.env  # optional custom settings
+    environment:
+      - REDIS_URL=redis://127.0.0.1:6379/0
+    restart: unless-stopped

--- a/scripts/macos-setup.sh
+++ b/scripts/macos-setup.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+#
+# macOS Setup Script for 8mb.local Native Worker
+#
+# This script sets up a native macOS worker that uses VideoToolbox
+# for hardware-accelerated video encoding on Apple Silicon (M1/M2/M3/M4).
+#
+# Architecture:
+#   - Docker: Runs Redis, frontend, and backend API
+#   - Native: Runs Celery worker with VideoToolbox access
+#
+
+set -e
+
+echo "=== 8mb.local macOS Worker Setup ==="
+echo ""
+
+# Check for Homebrew (needed if we need to install missing deps)
+HAS_BREW=false
+if command -v brew &> /dev/null; then
+    HAS_BREW=true
+fi
+
+# Check for Apple Silicon
+ARCH=$(uname -m)
+if [ "$ARCH" != "arm64" ]; then
+    echo "Warning: This script is optimized for Apple Silicon (arm64)."
+    echo "Detected architecture: $ARCH"
+    echo ""
+fi
+
+# Check for Python 3.10+
+PYTHON_CMD=""
+for cmd in python3 python; do
+    if command -v "$cmd" &> /dev/null; then
+        version=$("$cmd" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null)
+        major=$(echo "$version" | cut -d. -f1)
+        minor=$(echo "$version" | cut -d. -f2)
+        if [ "$major" -ge 3 ] && [ "$minor" -ge 10 ]; then
+            PYTHON_CMD="$cmd"
+            echo "Found Python $version"
+            break
+        fi
+    fi
+done
+
+if [ -z "$PYTHON_CMD" ]; then
+    echo "Python 3.10+ not found."
+    if [ "$HAS_BREW" = true ]; then
+        echo "Installing Python via Homebrew..."
+        brew install python
+        PYTHON_CMD="python3"
+    else
+        echo "Please install Python 3.10 or newer, or install Homebrew first."
+        exit 1
+    fi
+fi
+
+# Check for FFmpeg
+if ! command -v ffmpeg &> /dev/null; then
+    echo "FFmpeg not found."
+    if [ "$HAS_BREW" = true ]; then
+        echo "Installing FFmpeg via Homebrew..."
+        brew install ffmpeg
+    else
+        echo "Please install FFmpeg, or install Homebrew first."
+        exit 1
+    fi
+fi
+
+# Verify FFmpeg has VideoToolbox support
+if ! ffmpeg -encoders 2>/dev/null | grep -q "h264_videotoolbox"; then
+    echo "Error: FFmpeg does not have VideoToolbox support."
+    if [ "$HAS_BREW" = true ]; then
+        echo "Try reinstalling: brew reinstall ffmpeg"
+    fi
+    exit 1
+fi
+echo "FFmpeg VideoToolbox support: OK"
+
+# Setup Python virtual environment
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+echo ""
+echo "Setting up Python virtual environment..."
+cd "$PROJECT_DIR"
+
+if [ ! -d "venv" ]; then
+    "$PYTHON_CMD" -m venv venv
+fi
+
+source venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+echo ""
+echo "=== Setup Complete ==="
+echo ""
+echo "To run the worker:"
+echo ""
+echo "  1. Start Docker containers:"
+echo "     docker-compose -f docker-compose.macos.yml up -d"
+echo ""
+echo "  2. In a new terminal, start the native worker:"
+echo "     cd $PROJECT_DIR"
+echo "     source venv/bin/activate"
+echo "     export REDIS_URL=redis://localhost:6380/0"
+echo "     export UPLOAD_DIR=$PROJECT_DIR/uploads"
+echo "     export OUTPUT_DIR=$PROJECT_DIR/outputs"
+echo "     export PYTHONPATH=$PROJECT_DIR:$PROJECT_DIR/backend-api:$PROJECT_DIR/worker"
+echo "     celery -A worker.celery_app worker --loglevel=info"
+echo ""
+echo "  3. Open http://localhost:8001 in your browser"
+echo ""

--- a/worker/app/startup_tests.py
+++ b/worker/app/startup_tests.py
@@ -415,6 +415,13 @@ def run_startup_tests(hw_info: Dict) -> Dict[str, bool]:
                 ["-hwaccel", "vaapi", "-hwaccel_output_format", "vaapi"],
             ),
         }
+    elif hw_type_lower == "videotoolbox":
+        # VideoToolbox (macOS/Apple Silicon)
+        test_codecs = ["h264_videotoolbox", "hevc_videotoolbox"]
+        hw_decoders = {
+            "h264_videotoolbox": ("h264", ["-hwaccel", "videotoolbox"]),
+            "hevc_videotoolbox": ("hevc", ["-hwaccel", "videotoolbox"]),
+        }
 
     # Always test CPU fallbacks
     test_codecs.extend(["libx264", "libx265", "libaom-av1"])


### PR DESCRIPTION
Closes #15

## Summary
  - Adds hardware-accelerated video encoding support for Apple Silicon Macs (M1/M2/M3/M4)
  - Uses VideoToolbox via a hybrid setup: Docker for services, native macOS worker for GPU access
  - Supports H.264 and HEVC encoding (AV1 falls back to CPU as VideoToolbox doesn't support it)

  ## Architecture
  Since Docker Desktop on macOS runs in a Linux VM without GPU passthrough, this uses a hybrid approach:

  - **Docker**: Runs Redis, frontend, and backend API
  - **Native worker**: Runs on macOS with VideoToolbox access for hardware encoding
  - **Redis**: Exposed on port 6380 to avoid conflicts with native Redis installations

  ## Changes
  - `worker/app/hw_detect.py`: Added `_check_videotoolbox()` and encoder mappings
  - `worker/app/startup_tests.py`: Added VideoToolbox test configuration
  - `backend-api/app/models.py`: Added VideoToolbox codec literals
  - `backend-api/app/settings_manager.py`: Added VideoToolbox visibility settings
  - `docker-compose.macos.yml`: New compose file for macOS hybrid setup
  - `scripts/macos-setup.sh`: Setup script for native worker dependencies
  - `docs/GPU_SUPPORT.md`: Added VideoToolbox documentation
  - `README.md`: Updated macOS section with hybrid setup instructions
  - `.github/copilot-instructions.md`: Added VideoToolbox references
  - `.gitignore`: Added `venv/`

  ## Usage
  ```bash
  # Start Docker services
  docker-compose -f docker-compose.macos.yml up -d

  # Run setup script (installs FFmpeg/Python if needed)
  ./scripts/macos-setup.sh

  # Start native worker
  source venv/bin/activate
  export REDIS_URL=redis://localhost:6380/0
  celery -A worker.celery_app worker --loglevel=info

  Test plan

  - Verify VideoToolbox detection on Apple Silicon Mac
  - Test H.264 encoding with h264_videotoolbox
  - Test HEVC encoding with hevc_videotoolbox
  - Verify AV1 falls back to CPU encoding
  - Confirm setup script works on fresh macOS install
  - Test hybrid setup with Docker services + native worker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apple VideoToolbox hardware encoding support for macOS with H.264 and HEVC codecs
  * Introduced hybrid Docker + native worker setup for macOS with GPU acceleration

* **Documentation**
  * Updated macOS installation guide with two options: CPU-only and hardware-accelerated paths
  * Expanded GPU support documentation with VideoToolbox capabilities and limitations

* **Chores**
  * Added macOS environment setup script and Docker configuration for Apple Silicon

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->