### PR TITLE
Fixed resolutions scaling when using AMD VAAPI hardware acceleration.

### DIFF
--- a/worker/app/worker.py
+++ b/worker/app/worker.py
@@ -163,10 +163,12 @@ def compress_video(self, job_id: str, input_path: str, output_path: str, target_
     bufsize = int(video_kbps * 2)
 
     # Map requested codec to actual encoder and flags
+    actual_encoder, v_flags, init_hw_flags = map_codec_to_hw(video_codec, hw_info)
     
     # Fallback to CPU only if startup tests explicitly marked encoder as unavailable.
     # If cache is empty (tests still running in background), attempt hardware and rely on runtime fallback below.
-    original_encoder = actual_encoder    if actual_encoder not in ("libx264", "libx265", "libaom-av1"):
+    original_encoder = actual_encoder
+    if actual_encoder not in ("libx264", "libx265", "libaom-av1"):
         global ENCODER_TEST_CACHE
         cache_key = f"{actual_encoder}:{':'.join(init_hw_flags)}"
         if cache_key in ENCODER_TEST_CACHE and not ENCODER_TEST_CACHE[cache_key]:


### PR DESCRIPTION
When using resolution scaling (auto or manual) with VAAPI hardware encoders, hardware encoding would fail and would fallback to CPU encoding instead.

## Issue 1: Wrong filter order. Tried to scale on CPU before using VAAPI hardware
### BEFORE (Broken):
-vf **scale**=-2:'min(ih,1080)',format=nv12|vaapi,hwupload
### AFTER (Fixed):
-vf format=nv12|vaapi,hwupload,**scale_vaapi**=-2:'min(ih,1080)'

The original version resulted in a ffmpeg error "Error while filtering: Function not implemente" triggering the CPU fallback.

## Issue 2: Duplicate filters (-vf) when using VAAPI.
This resulted in ffmpeg commands like this: ffmpeg -c:v hevc_vaapi -vf format=nv12|vaapi,hwupload -vf scale=-2:1080,format=nv12|vaapi,hwupload.

## Test:
Tested on AMD Ryzen 9 7940HS w/ Radeon 780M Graphics  on Arch Linux.
<img width="1159" height="968" alt="image" src="https://github.com/user-attachments/assets/832962ea-ffa5-4617-8689-43b2e4c8371c" />

## Notes:
I suspect intel QuickSync has a similar issue but cannot conform myself as I don't have the hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced video encoding with VAAPI hardware acceleration. Video scaling filters now apply correctly when using VAAPI-based encoders, ensuring optimal GPU-accelerated encoding performance. Non-VAAPI encoders remain unaffected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->