### PR TITLE
Fix native Windows QSV frame uploads

### DIFF
--- a/docs/GPU_SUPPORT.md
+++ b/docs/GPU_SUPPORT.md
@@ -46,11 +46,12 @@ specific render node (for example `/dev/dri/renderD129`). The worker discovers
 render nodes when the variable is empty and checks the sysfs vendor before it
 attempts QSV, so an AMD node is never misidentified as Intel QSV.
 
-The encoder path uses software decode and scaling followed by an explicit
-hardware upload: `format=nv12,hwupload=extra_hw_frames=64` for QSV and
-`format=nv12|vaapi,hwupload` for VAAPI. This is intentional: it preserves
-rotation metadata and makes scaling/fps filters consistent across Intel and
-AMD driver versions.
+The encoder path uses software decode and scaling. Linux QSV then uses
+`format=nv12,hwupload=extra_hw_frames=64`, while native Windows QSV receives
+NV12 software frames and performs its upload internally. This platform split
+avoids D3D11 texture-pool failures on rotated/vertical AV1 inputs while keeping
+the fixed pool required by Linux oneVPL. VAAPI uses
+`format=nv12|vaapi,hwupload`.
 The startup test and the job command use the same VAAPI/QSV initialization
 sequence.
 

--- a/docs/releases/v138.md
+++ b/docs/releases/v138.md
@@ -34,6 +34,9 @@ SvelteKit/FastAPI/worker behavior across platforms.
   The QSV path now uses a fixed hardware-frame pool required by Intel's media
   driver. Unsupported AV1 QSV falls back to SVT-AV1 instead of hanging or
   reporting a false hardware pass.
+- Native Windows QSV uses the encoder's internal upload instead of Linux's
+  explicit hardware upload. This fixes D3D11 frame-pool failures on real
+  rotated 1080×1920 AV1 jobs; the startup probe now tests that realistic shape.
 - Linux VAAPI: H.264 and HEVC passed through the application using a real
   `/dev/dri` Intel render node. AMD Linux acceleration uses this VAAPI path.
 - Windows AMD AMF: support is exposed only after a real encoder initialization

--- a/worker/app/qsv_filters.py
+++ b/worker/app/qsv_filters.py
@@ -1,0 +1,23 @@
+"""Platform-specific QSV software-frame filter selection."""
+from __future__ import annotations
+
+import sys
+
+
+def qsv_input_filter(platform: str | None = None) -> str:
+    """Return the safe software-decode-to-QSV filter for this platform.
+
+    Linux oneVPL requires an explicitly sized hardware frame pool. Native
+    Windows QSV accepts NV12 software frames and uploads them internally;
+    forcing a D3D11 hwupload can fail on real vertical/rotated AV1 surfaces
+    even though a small synthetic initialization probe succeeds.
+    """
+    current = platform or sys.platform
+    if current == "win32":
+        return "format=nv12"
+    return "format=nv12,hwupload=extra_hw_frames=64"
+
+
+def qsv_probe_size(platform: str | None = None) -> str:
+    """Exercise a realistic vertical surface in native Windows probes."""
+    return "1080x1920" if (platform or sys.platform) == "win32" else "256x256"

--- a/worker/app/startup_tests.py
+++ b/worker/app/startup_tests.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, List, Tuple
 from shared.subprocess_utils import hidden_process_kwargs
 
 from .constants import AMF_ENCODERS, CPU_ENCODERS, QSV_ENCODERS, VAAPI_ENCODERS
+from .qsv_filters import qsv_input_filter, qsv_probe_size
 
 logger = logging.getLogger(__name__)
 
@@ -205,13 +206,14 @@ def test_encoder_init(encoder_name: str, hw_flags: List[str]) -> Tuple[bool, str
     hardware upload from the lavfi source.
     """
     try:
+        source_size = qsv_probe_size(sys.platform) if encoder_name in QSV_ENCODERS else "256x256"
         cmd = [
             "ffmpeg", "-hide_banner", "-y",
             *hw_flags,
-            "-f", "lavfi", "-i", "color=black:s=256x256:d=0.1:r=1",
+            "-f", "lavfi", "-i", f"color=black:s={source_size}:d=0.1:r=1",
         ]
         if encoder_name in QSV_ENCODERS or encoder_name in VAAPI_ENCODERS:
-            upload_filter = "format=nv12,hwupload=extra_hw_frames=64"
+            upload_filter = qsv_input_filter(sys.platform)
             if encoder_name in VAAPI_ENCODERS:
                 upload_filter = "format=nv12|vaapi,hwupload"
             cmd += ["-vf", upload_filter]

--- a/worker/app/tasks.py
+++ b/worker/app/tasks.py
@@ -30,6 +30,7 @@ from .hw_detect import get_hw_info, map_codec_to_hw, choose_best_codec
 from .ffmpeg_helpers import cpu_filter_chain, replace_bitrate_args
 from .startup_tests import run_startup_tests
 from .progress import parse_ffmpeg_out_time, parse_time_string
+from .qsv_filters import qsv_input_filter
 
 logger = logging.getLogger(__name__)
 
@@ -821,13 +822,17 @@ def compress_video(self, job_id: str, input_path: str, output_path: str, target_
     # scaling remain the most reliable path across Intel/AMD driver versions.
     # Upload only after all software filters (scale/fps) have been applied.
     if actual_encoder in QSV_ENCODERS:
-        # QSV requires a fixed hardware-frame pool when software-decoded frames
-        # are uploaded. Without this, Intel media-driver fails at runtime with
-        # "QSV requires a fixed frame pool size" despite a healthy device.
-        vf_filters.append("format=nv12,hwupload=extra_hw_frames=64")
+        # Linux oneVPL requires a fixed pool; native Windows QSV performs its
+        # own upload because explicit D3D11 hwupload rejects some real-world
+        # rotated/vertical AV1 surfaces with E_INVALIDARG (0x80070057).
+        qsv_filter = qsv_input_filter(sys.platform)
+        vf_filters.append(qsv_filter)
         _publish(self.request.id, {
             "type": "log",
-            "message": f"Encoder: {actual_encoder} with software decode and QSV hardware upload",
+            "message": (
+                f"Encoder: {actual_encoder} with software decode and "
+                + ("QSV internal upload" if sys.platform == "win32" else "QSV hardware upload")
+            ),
         })
     elif actual_encoder in VAAPI_ENCODERS:
         # Allow an already-uploaded VAAPI frame as well as software nv12.

--- a/worker/tests/test_hw_acceleration.py
+++ b/worker/tests/test_hw_acceleration.py
@@ -7,6 +7,7 @@ import worker.app.hw_detect as hw_detect
 from worker.app.startup_tests import test_encoder_init as run_encoder_init
 from worker.app.ffmpeg_helpers import cpu_filter_chain, replace_bitrate_args
 from worker.app.tasks import _publish
+from worker.app.qsv_filters import qsv_input_filter, qsv_probe_size
 
 
 class TestHardwareMapping(unittest.TestCase):
@@ -124,6 +125,17 @@ class TestHardwareMapping(unittest.TestCase):
 
 
 class TestHardwareFallbackHelpers(unittest.TestCase):
+    def test_windows_qsv_uses_internal_upload_for_real_surfaces(self):
+        self.assertEqual(qsv_input_filter("win32"), "format=nv12")
+        self.assertEqual(qsv_probe_size("win32"), "1080x1920")
+
+    def test_linux_qsv_keeps_fixed_hardware_frame_pool(self):
+        self.assertEqual(
+            qsv_input_filter("linux"),
+            "format=nv12,hwupload=extra_hw_frames=64",
+        )
+        self.assertEqual(qsv_probe_size("linux"), "256x256")
+
     @patch("worker.app.tasks._redis")
     def test_progress_publish_failure_does_not_raise(self, redis_factory):
         redis_factory.return_value.publish.side_effect = ConnectionError("redis unavailable")
@@ -143,6 +155,25 @@ class TestHardwareFallbackHelpers(unittest.TestCase):
 
 
 class TestStartupProbeCommand(unittest.TestCase):
+    @patch("worker.app.startup_tests.sys.platform", "win32")
+    @patch("worker.app.startup_tests.subprocess.run")
+    def test_windows_qsv_probe_matches_vertical_internal_upload_path(self, run):
+        class Result:
+            returncode = 0
+            stderr = ""
+
+        run.return_value = Result()
+        ok, _message = run_encoder_init(
+            "av1_qsv",
+            ["-init_hw_device", "qsv=hw", "-filter_hw_device", "hw"],
+        )
+        self.assertTrue(ok)
+        command = run.call_args.args[0]
+        self.assertIn("color=black:s=1080x1920:d=0.1:r=1", command)
+        self.assertIn("format=nv12", command)
+        self.assertNotIn("hwupload", " ".join(command))
+
+    @patch("worker.app.startup_tests.sys.platform", "linux")
     @patch("worker.app.startup_tests.subprocess.run")
     def test_qsv_startup_probe_contains_correct_device_init(self, run):
         class Result:


### PR DESCRIPTION
Use QSV internal upload on Windows while preserving the fixed oneVPL frame pool on Linux. Probe realistic vertical AV1 surfaces and document the platform-specific pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows QSV encoding for rotated 1080×1920 AV1 video.
  * Resolved startup and frame-pool failures by using the appropriate platform-specific hardware upload behavior.
  * Preserved reliable QSV and VAAPI encoding behavior across supported platforms.

* **Documentation**
  * Updated GPU support and release documentation to explain platform-specific QSV behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->